### PR TITLE
Remove the nonexistent method and pass the test after removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Compiled class file
 *.class
 *.iml
+*.idea
 
 # Log file
 *.log

--- a/itstack-demo-bytecode-4-05/src/main/java/org/itstack/demo/agent/MyAgent.java
+++ b/itstack-demo-bytecode-4-05/src/main/java/org/itstack/demo/agent/MyAgent.java
@@ -36,7 +36,7 @@ public class MyAgent {
             return builder;
         };
 
-        agentBuilder = agentBuilder.type(ElementMatchers.nameStartsWith("org.itstack.demo.test")).transform(transformer).asDecorator();
+        agentBuilder = agentBuilder.type(ElementMatchers.nameStartsWith("org.itstack.demo.test")).transform(transformer);
 
         //监听
         AgentBuilder.Listener listener = new AgentBuilder.Listener() {

--- a/itstack-demo-bytecode-4-06/src/main/java/org/itstack/demo/agent/MyAgent.java
+++ b/itstack-demo-bytecode-4-06/src/main/java/org/itstack/demo/agent/MyAgent.java
@@ -36,7 +36,7 @@ public class MyAgent {
                     builder = builder.visit(Advice.to(plugin.adviceClass()).on(point.buildMethodsMatcher()));
                     return builder;
                 };
-                agentBuilder = agentBuilder.type(point.buildTypesMatcher()).transform(transformer).asDecorator();
+                agentBuilder = agentBuilder.type(point.buildTypesMatcher()).transform(transformer);
             }
         }
 


### PR DESCRIPTION
remove byte-buddy not exist method:asDecorator().

```xml
        <dependency>
            <groupId>net.bytebuddy</groupId>
            <artifactId>byte-buddy</artifactId>
            <version>1.10.9</version>
        </dependency>
```

![image](https://user-images.githubusercontent.com/12478263/158017185-7964295e-d435-4e70-9c39-e0ecb12cee42.png)
I've tested it

